### PR TITLE
Bumped version to 0.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ CHANGELOG
 =========
 
 
-0.5.0 (unreleased)
+0.5.0 (2020-09-01)
 ==================
 
 * Added support for Django 3.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 # we need to declare the version here
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 
 REQUIREMENTS = [


### PR DESCRIPTION
* Added support for Django 3.1
* Dropped support for Python 2.7 and Python 3.4
* Dropped support for Django < 2.2
* Changed ``default_acl`` to ``object_parameters``