### PR TITLE
Remove comma to be compatible with Python 3.6

### DIFF
--- a/django_storage_url/backends/az.py
+++ b/django_storage_url/backends/az.py
@@ -22,7 +22,7 @@ class AzureStorage(azure_storage.AzureStorage):
         dsn,
         *,
         ensure_container_exists=True,
-        preserve_compressed_files=True,
+        preserve_compressed_files=True
     ):
         account_name = dsn.username
         credential = dsn.password


### PR DESCRIPTION
From black:

> One exception to adding trailing commas is function signatures containing *, *args, or **kwargs. In this case a trailing comma is only safe to use on Python 3.6. Black will detect if your file is already 3.6+ only and use trailing commas in this situation. If you wonder how it knows, it looks for f-strings and existing use of trailing commas in function signatures that have stars in them. In other words, if you’d like a trailing comma in this situation and Black didn’t recognize it was safe to do so, put it there manually and Black will keep it.