### PR TITLE
fix: remove hard-coded overwrite_files in AzureStorage

### DIFF
--- a/django_storage_url/backends/az.py
+++ b/django_storage_url/backends/az.py
@@ -3,6 +3,7 @@ from urllib.parse import parse_qs
 
 import furl
 from storages.backends import azure_storage
+from django.conf import settings
 
 
 class AzureStorageFile(azure_storage.AzureStorageFile):
@@ -56,7 +57,8 @@ class AzureStorage(azure_storage.AzureStorage):
         self.azure_container = container_name
         self.azure_ssl = secure_urls
         self.max_memory_size = 10 * 1024**2
-        self.overwrite_files = True
+        # The default is False in the superclass
+        self.overwrite_files = getattr(settings, "AZURE_OVERWRITE_FILES", True)
         self.location = ""
         self.base_url = str(base_url)
 


### PR DESCRIPTION
The `overwrite_files` is False by default in django-storages, and we so far hardcoded it to `True`.  However, users should be able to change it to their liking from the django settings using `AZURE_OVERWRITE_FILES`.

Removing this override keeps the default behaviour (`True`), while still allowing users to change it.

NOTE: I stumbled upon this limitation because django-storages changed the semantics of the `.exists()` function in their latest release, which now returns whether a path is free for upload (and not whether the file already exists on the remote storage). With `overwrite_files` set to True, `.exists()` will now always return False. It seems they are aware of the counter-intuitiveness of this change and will rollback soon.

See https://github.com/jschneier/django-storages/issues/1430